### PR TITLE
Don't JSON-encode model errors.

### DIFF
--- a/src/RichardLawley.WebApi.FluentValidation/FluentValidationActionFilter.cs
+++ b/src/RichardLawley.WebApi.FluentValidation/FluentValidationActionFilter.cs
@@ -12,7 +12,6 @@ using System.Web.Http.ModelBinding;
 using FluentValidation;
 using FluentValidation.Internal;
 using FluentValidation.Results;
-using Newtonsoft.Json;
 using RichardLawley.WebApi.OrderedFilters;
 
 namespace RichardLawley.WebApi.FluentValidation
@@ -116,7 +115,7 @@ namespace RichardLawley.WebApi.FluentValidation
                             return false;
                         }
                     }
-                    validationContext.ModelState.AddModelError(key, JsonConvert.SerializeObject(error));
+                    validationContext.ModelState.AddModelError(error.PropertyName, error.ErrorMessage);
                     isValid = false;
                 }
             }


### PR DESCRIPTION
After encountering issue #3, our team fixed the issue with this change. Rather than JSON-encoding the error, we add a model error using the error's PropertyName and ErrorMessage.
